### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Fetch TShock
       run: |
-        $r = curl -UseBasicParsing -H @{'Accept' = 'application/vnd.github.v3+json'} https://api.github.com/repos/Pryaxis/TShock/releases
+        $r = curl -UseBasicParsing -H @{'Accept' = 'application/vnd.github.v3+json'} https://api.github.com/repos/Pryaxis/TShock/releases/latest
         $parsed = $r.content |ConvertFrom-Json
         Invoke-WebRequest $parsed.assets.browser_download_url -outfile tshock.zip
     - name: Decompress

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         $r = curl -UseBasicParsing -H @{'Accept' = 'application/vnd.github.v3+json'} https://api.github.com/repos/Pryaxis/TShock/releases/latest
         $parsed = $r.content |ConvertFrom-Json
         Invoke-WebRequest $parsed.assets.browser_download_url -outfile tshock.zip
+      shell: powershell
     - name: Decompress
       run: 7z.exe e tshock.zip -oEssentialsPlus\References "ServerPlugins/TShockAPI.dll" "Newtonsoft.Json.dll" "Mono.Data.Sqlite.dll" "MySql.Data.dll" "TerrariaServer.exe" "OTAPI.dll" -r
       shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: BuildRelease
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch TShock
+      run: curl -L "https://github.com/Pryaxis/TShock/releases/download/v4.5.4/TShock4.5.4_Terraria1.4.2.3.zip" > tshock.zip
+      shell: cmd
+    - name: Decompress
+      run: 7z.exe e tshock.zip -oEssentialsPlus\References "ServerPlugins/TShockAPI.dll" "Newtonsoft.Json.dll" "Mono.Data.Sqlite.dll" "MySql.Data.dll" "TerrariaServer.exe" "OTAPI.dll" -r
+      shell: cmd
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Build
+      run: msbuild EssentialsPlus.sln /p:Configuration=Release
+    - name: Create release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: EssentialsPlus\bin\Release\EssentialsPlus.dll
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Fetch TShock
-      run: curl -L "https://github.com/Pryaxis/TShock/releases/download/v4.5.4/TShock4.5.4_Terraria1.4.2.3.zip" > tshock.zip
+      run: curl -L "https://ghd.one/Pryaxis/TShock?includes=TShock&excludes=&download=true" > tshock.zip
       shell: cmd
     - name: Decompress
       run: 7z.exe e tshock.zip -oEssentialsPlus\References "ServerPlugins/TShockAPI.dll" "Newtonsoft.Json.dll" "Mono.Data.Sqlite.dll" "MySql.Data.dll" "TerrariaServer.exe" "OTAPI.dll" -r

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Fetch TShock
-      run: curl -L "https://ghd.one/Pryaxis/TShock?includes=TShock&excludes=&download=true" > tshock.zip
-      shell: cmd
+      run: |
+        $r = curl -UseBasicParsing -H @{'Accept' = 'application/vnd.github.v3+json'} https://api.github.com/repos/Pryaxis/TShock/releases
+        $parsed = $r.content |ConvertFrom-Json
+        Invoke-WebRequest $parsed.assets.browser_download_url -outfile tshock.zip
     - name: Decompress
       run: 7z.exe e tshock.zip -oEssentialsPlus\References "ServerPlugins/TShockAPI.dll" "Newtonsoft.Json.dll" "Mono.Data.Sqlite.dll" "MySql.Data.dll" "TerrariaServer.exe" "OTAPI.dll" -r
       shell: cmd


### PR DESCRIPTION
Hey again,

I've set up a workflow to automatically build and attach a release DLL to an existing Github release.

Just create a tag to get a new build published. In my testing the only issue with the latest version is the owners group isn't seen as as powerful as the superadmins group, haven't worked out a fix. 

Thanks!
~Tanner